### PR TITLE
Localization file feature

### DIFF
--- a/TimberAPI/Localization/Localization.cs
+++ b/TimberAPI/Localization/Localization.cs
@@ -45,13 +45,21 @@ namespace TimberbornAPI.Localizations {
             /// File localization, overwrites code localization, has any localization
             /// Missing file localization, defaults back to enUS, overwrites code localization
             /// </summary>
-            private static void Postfix(string localizationKey, IDictionary<string, string> __result)
+            private static void Postfix(string localizationKey, ref IDictionary<string, string> __result)
             {
-                IDictionary<string, string> localization = new Dictionary<string, string>();
+                IDictionary<string, string> localization = new Dictionary<string, string>(labelsToInject);
                 IDictionary<string, string> fileLocalization = LocalizationRepository.GetLocalization(localizationKey);
-                foreach ((string locKey, string locValue) in labelsToInject)
+                
+                foreach ((string locKey, string locValue) in fileLocalization)
                 {
-                    localization.Add(locKey, fileLocalization.ContainsKey(locKey) ? fileLocalization[locKey] : locValue);
+                    if (localization.ContainsKey(locKey))
+                    {
+                        localization[locKey] = locValue;
+                    }
+                    else
+                    {
+                        localization.Add(locKey, locValue);
+                    }
                 }
 
                 try

--- a/TimberAPI/Localization/Localization.cs
+++ b/TimberAPI/Localization/Localization.cs
@@ -1,13 +1,15 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
 using HarmonyLib;
 using Timberborn.Common;
-using Timberborn.Localization;
 
 namespace TimberbornAPI.Localizations {
     [HarmonyPatch]
-    public class Localization : ILocalization {
+    public class Localization : ILocalization
+    {
         private static Dictionary<string, string> labelsToInject = new();
-
+        
         /**
          * Add a label into the current localization
          * 
@@ -24,15 +26,44 @@ namespace TimberbornAPI.Localizations {
         public void AddLabels(Dictionary<string, string> labels) {
             labelsToInject.AddRange(labels);
         }
+        
+        [HarmonyPatch]
+        public static class LocalizationPatch
+        {
+            /// <summary>
+            /// Set the target method using reflection
+            /// </summary>
+            /// <returns></returns>
+            private static MethodInfo TargetMethod()
+            {
+                return AccessTools.TypeByName("Timberborn.Localization.LocalizationRepository").GetMethod("GetLocalization");
+            }
+            
+            /// <summary>
+            /// Adds custom localization
+            /// Code localization, applies to all languages
+            /// File localization, overwrites code localization, has any localization
+            /// Missing file localization, defaults back to enUS, overwrites code localization
+            /// </summary>
+            private static void Postfix(string localizationKey, IDictionary<string, string> __result)
+            {
+                IDictionary<string, string> localization = new Dictionary<string, string>();
+                IDictionary<string, string> fileLocalization = LocalizationRepository.GetLocalization(localizationKey);
+                foreach ((string locKey, string locValue) in labelsToInject)
+                {
+                    localization.Add(locKey, fileLocalization.ContainsKey(locKey) ? fileLocalization[locKey] : locValue);
+                }
 
-        /**
-         * Inject labels into the current localization
-         */
-        [HarmonyPrefix]
-        [HarmonyPatch(typeof(Loc), "Initialize")]
-        static bool InjectLabels(ref Dictionary<string, string> localization) {
-            localization.AddRange(labelsToInject);
-            return true;
+                try
+                {
+                    __result.AddRange(localization);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    throw;
+                }
+            }
         }
     }
 }

--- a/TimberAPI/Localization/LocalizationRecord.cs
+++ b/TimberAPI/Localization/LocalizationRecord.cs
@@ -1,0 +1,21 @@
+using LINQtoCSV;
+
+namespace TimberbornAPI.Localizations
+{
+    /// <summary>
+    /// Timberborn code Timberborn.Localization.LocalizationRecord
+    /// </summary>
+    public class LocalizationRecord
+    {
+        [CsvColumn(Name = "ID")]
+        public string Id { get; set; }
+
+        [CsvColumn(Name = "Text")]
+        public string Text { get; set; }
+
+        [CsvColumn(Name = "Comment")]
+        public string Comment { get; set; }
+
+        public bool IsWip { get; set; }
+    }
+}

--- a/TimberAPI/Localization/LocalizationRepository.cs
+++ b/TimberAPI/Localization/LocalizationRepository.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BepInEx.Bootstrap;
+using Timberborn.Localization;
+using LINQtoCSV;
+using TimberbornAPI.Internal;
+using UnityEngine;
+
+namespace TimberbornAPI.Localizations
+{
+    internal static class LocalizationRepository
+    {
+        /// <summary>
+        /// Modified timberborn method Timberborn.Localization.LocalizationRepository.GetLocalization
+        /// </summary>
+        /// <param name="localizationKey"></param>
+        /// <returns></returns>
+        public static IDictionary<string, string> GetLocalization(string localizationKey)
+        {
+            Dictionary<string, string> dictionary1 = new Dictionary<string, string>();
+            Dictionary<string, string> dictionary2 = GetLocalizationRecordsFromFiles(localizationKey, GetLocalizationFilePathsFromDependencies(localizationKey)).ToDictionary(record => record.Id, record => record.Text);
+            
+            foreach (LocalizationRecord localizationRecord in GetDefaultLocalization())
+            {
+                string id = localizationRecord.Id;
+                if (dictionary2.TryGetValue(id, out string text) && !string.IsNullOrEmpty(text))
+                {
+                    dictionary1[id] = TextColors.ColorizeText(text);
+                }
+                else
+                {
+                    dictionary1[id] = TextColors.ColorizeText(localizationRecord.Text);
+                }
+            }
+
+            return dictionary1;
+        }
+        
+        /// <summary>
+        /// Parses text files into LocalizationRecords
+        /// </summary>
+        /// <param name="localization"></param>
+        /// <param name="filePaths"></param>
+        /// <returns></returns>
+        private static IEnumerable<LocalizationRecord> GetLocalizationRecordsFromFiles(string localization, IEnumerable<string> filePaths)
+        {
+            List<LocalizationRecord> records = new List<LocalizationRecord>();
+            foreach (string path in filePaths)
+            {
+                records.AddRange(TryToReadRecords(localization, path));
+            }
+
+            return records;
+        }
+
+        /// <summary>
+        /// Timberborn method Timberborn.Localization.LocalizationRepository.TryToReadRecords
+        /// </summary>
+        /// <param name="localization"></param>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidDataException"></exception>
+        private static IEnumerable<LocalizationRecord> TryToReadRecords(string localization, string filePath)
+        {
+            try
+            {
+                return new CsvContext().Read<LocalizationRecord>(filePath);
+            }
+            catch (Exception ex)
+            {
+                string message = "Unable to parse file for " + localization + ".";
+                if (ex is AggregatedException aggregatedException1)
+                    message = message + " First error: " + ((List<Exception>) aggregatedException1.m_InnerExceptionsList)[0].Message;
+                if (localization == LocalizationCodes.Default)
+                    throw new InvalidDataException(message, ex);
+                Debug.LogError((object) message);
+                return new List<LocalizationRecord>();
+            }
+        }
+
+        /// <summary>
+        /// Returns the default localization
+        /// </summary>
+        private static IEnumerable<LocalizationRecord> GetDefaultLocalization() => GetLocalizationRecordsFromFiles(LocalizationCodes.Default, GetLocalizationFilePathsFromDependencies(LocalizationCodes.Default));
+
+        /// <summary>
+        /// Searches for depencies
+        /// </summary>
+        /// <param name="localizationKey"></param>
+        /// <returns></returns>
+        private static List<string> GetLocalizationFilePathsFromDependencies(string localizationKey)
+        {
+            List<string> localizationFilePaths = new List<string>();
+            foreach (KeyValuePair<string, BepInEx.PluginInfo> keyValuePair in Chainloader.PluginInfos.Where(kv => kv.Value.Dependencies.Any(dep => dep.DependencyGUID == TimberAPIPlugin.Guid)))
+            {
+                string pluginLocalizationPath = Path.Combine(Path.GetDirectoryName(keyValuePair.Value.Location) ?? string.Empty, "lang");
+                (bool hasLocalization, string localizationName) = LocalizationNameOrDefault(pluginLocalizationPath, localizationKey);
+
+                if(!hasLocalization)
+                    continue;
+                localizationFilePaths.Add(Path.Combine(pluginLocalizationPath, localizationName));
+            }
+
+            return localizationFilePaths;
+        }
+        
+        /// <summary>
+        /// Check if localization file exists, return default if not
+        /// Returns false if default and localization file doesn't exists 
+        /// </summary>
+        /// <param name="pluginLocalizationPath"></param>
+        /// <param name="localizationName"></param>
+        private static (bool, string) LocalizationNameOrDefault(string pluginLocalizationPath, string localizationName)
+        {
+            if (string.IsNullOrEmpty(localizationName))
+                return (false, "");
+            
+            if (!Directory.Exists(pluginLocalizationPath))
+                return (false, "");
+            
+            if(File.Exists(Path.Combine(pluginLocalizationPath, localizationName + ".txt")))
+                return (true, localizationName + ".txt");
+            
+            if (File.Exists(Path.Combine(pluginLocalizationPath, LocalizationCodes.Default + ".txt")))
+                return (true, LocalizationCodes.Default + ".txt");
+            
+            return (false, "");
+        }
+    }
+}

--- a/TimberAPI/Localization/LocalizationRepository.cs
+++ b/TimberAPI/Localization/LocalizationRepository.cs
@@ -17,7 +17,7 @@ namespace TimberbornAPI.Localizations
         /// </summary>
         /// <param name="localizationKey"></param>
         /// <returns></returns>
-        public static IDictionary<string, string> GetLocalization(string localizationKey)
+        public static Dictionary<string, string> GetLocalization(string localizationKey)
         {
             Dictionary<string, string> dictionary1 = new Dictionary<string, string>();
             Dictionary<string, string> dictionary2 = GetLocalizationRecordsFromFiles(localizationKey, GetLocalizationFilePathsFromDependencies(localizationKey)).ToDictionary(record => record.Id, record => record.Text);

--- a/TimberAPI/Localization/LocalizationRepository.cs
+++ b/TimberAPI/Localization/LocalizationRepository.cs
@@ -12,6 +12,8 @@ namespace TimberbornAPI.Localizations
 {
     internal static class LocalizationRepository
     {
+        public const string LocalizationPathKey = "lang";
+
         /// <summary>
         /// Modified timberborn method Timberborn.Localization.LocalizationRepository.GetLocalization
         /// </summary>
@@ -95,7 +97,7 @@ namespace TimberbornAPI.Localizations
             List<string> localizationFilePaths = new List<string>();
             foreach (KeyValuePair<string, BepInEx.PluginInfo> keyValuePair in Chainloader.PluginInfos.Where(kv => kv.Value.Dependencies.Any(dep => dep.DependencyGUID == TimberAPIPlugin.Guid)))
             {
-                string pluginLocalizationPath = Path.Combine(Path.GetDirectoryName(keyValuePair.Value.Location) ?? string.Empty, "lang");
+                string pluginLocalizationPath = Path.Combine(Path.GetDirectoryName(keyValuePair.Value.Location) ?? string.Empty, LocalizationPathKey);
                 (bool hasLocalization, string localizationName) = LocalizationNameOrDefault(pluginLocalizationPath, localizationKey);
 
                 if(!hasLocalization)

--- a/TimberAPI/TimberAPI.csproj
+++ b/TimberAPI/TimberAPI.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="BepInEx.Analyzers" Version="1.0.6" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.4.16" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.1.0" />
+    <PackageReference Include="LinqToCsv" Version="1.5.0" />
     <PackageReference Include="UnityEngine.Modules" Version="2021.1.27" IncludeAssets="compile" />
   </ItemGroup>
   

--- a/TimberAPI/TimberAPIPlugin.cs
+++ b/TimberAPI/TimberAPIPlugin.cs
@@ -6,6 +6,7 @@ namespace TimberbornAPI.Internal {
 
     [BepInPlugin("com.timberapi.timberapi", "TimberAPI", "0.1.0")]
     public class TimberAPIPlugin : BaseUnityPlugin {
+        public static string Guid = "com.timberapi.timberapi";
 
         public void Awake() {
             var harmony = new Harmony("com.timberapi.plugin");


### PR DESCRIPTION
Added file reading language files for localization.

- Changed patch to work with reflections and moved patch from Loc to LocalizationRepository
- Localization files read by LocalizationRepository localizationkey, doesn't need updates when changed or added new languages
- Overrides code added labels
- Fallback to enUS
- Added LinqToCsv to read csv files
- Default language location: dll path -> lang
- Added static Guid string to TimberAPIPlugin to remove magic string in repository
- Added LocalizationPathKey to remove magic string in repository