### PR TITLE
IApiSpecificationService

### DIFF
--- a/Core/TimberApi/SpecificationSystem/IApiSpecificationService.cs
+++ b/Core/TimberApi/SpecificationSystem/IApiSpecificationService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Timberborn.Persistence;
+
+namespace TimberApi.SpecificationSystem
+{
+    public interface IApiSpecificationService : ISpecificationService
+    {
+        IEnumerable<T> GetSpecifications<T>(string specificationName, IObjectSerializer<T> serializer);
+
+        IEnumerable<(ISpecification, string)> GetSpecificationJsons(string specificationName);
+    }
+}

--- a/Core/TimberApi/SpecificationSystem/SpecificationSystemConfigurator.cs
+++ b/Core/TimberApi/SpecificationSystem/SpecificationSystemConfigurator.cs
@@ -12,6 +12,7 @@ namespace TimberApi.SpecificationSystem
         {
             containerDefinition.Bind<SpecificationRepository>().AsSingleton();
             containerDefinition.Bind<ISpecificationService>().To<ApiSpecificationService>().AsSingleton();
+            containerDefinition.Bind<IApiSpecificationService>().To<ApiSpecificationService>().AsSingleton();
             containerDefinition.Bind<SpecificationGenerator>().AsSingleton();
         }
     }


### PR DESCRIPTION
Makes it possible to have more custom control over the specifications while still keeping the merging intact.

Use cases;
- Different specification names, same serializers or reverst
- Custom serializers other than the one from te game.