### PR TITLE
Fixed priority highlighting

### DIFF
--- a/Core/TimberApi/BottomBarSystem/Patchers/ToolButtonPatcher.cs
+++ b/Core/TimberApi/BottomBarSystem/Patchers/ToolButtonPatcher.cs
@@ -1,7 +1,9 @@
 using HarmonyLib;
 using TimberApi.HarmonyPatcherSystem;
 using TimberApi.SceneSystem;
+using Timberborn.BuilderPrioritySystemUI;
 using Timberborn.ToolSystem;
+using UnityEngine;
 
 namespace TimberApi.BottomBarSystem.Patchers
 {
@@ -14,7 +16,7 @@ namespace TimberApi.BottomBarSystem.Patchers
         public override void Apply(Harmony harmony)
         {
             harmony.Patch(
-                GetMethodInfo<ToolButton>("OnButtonClicked"),
+                GetMethodInfo<ToolButton>(nameof(ToolButton.OnButtonClicked)),
                 prefix: GetHarmonyMethod(nameof(OnButtonClickedPatch))
             );
         }

--- a/Core/TimberApi/BottomBarSystem/Patchers/ToolGroupButtonPatcher.cs
+++ b/Core/TimberApi/BottomBarSystem/Patchers/ToolGroupButtonPatcher.cs
@@ -99,7 +99,7 @@ namespace TimberApi.BottomBarSystem.Patchers
 
         public static bool OnToolGroupExited(ToolGroupExitedEvent toolGroupExitedEvent, ToolGroupButton __instance, VisualElement ____toolGroupButtonWrapper)
         {
-            if(toolGroupExitedEvent.ToolGroup is not ExitingTool) return false;
+            if(toolGroupExitedEvent.ToolGroup is not ExitingToolGroup) return false;
 
             __instance.ToolButtonsElement.ToggleDisplayStyle(false);
             ____toolGroupButtonWrapper.RemoveFromClassList(ActiveClassName);

--- a/Core/TimberApi/BottomBarSystem/Patchers/ToolGroupManagerPatcher.cs
+++ b/Core/TimberApi/BottomBarSystem/Patchers/ToolGroupManagerPatcher.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using TimberApi.HarmonyPatcherSystem;
 using TimberApi.SceneSystem;
 using TimberApi.ToolGroupSystem;
+using Timberborn.SingletonSystem;
 using Timberborn.ToolSystem;
 
 namespace TimberApi.BottomBarSystem.Patchers
@@ -10,7 +11,7 @@ namespace TimberApi.BottomBarSystem.Patchers
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public class ToolGroupManagerPatcher : BaseHarmonyPatcher
     {
-        private static readonly ToolGroup ExitingToolGroup = new ExitingTool();
+        private static readonly ToolGroup ExitingToolGroup = new ExitingToolGroup();
 
         public override string UniqueId => "TimberApi.ToolGroupManager";
 
@@ -27,7 +28,7 @@ namespace TimberApi.BottomBarSystem.Patchers
             return sceneEntrypoint == SceneEntrypoint.InGame;
         }
 
-        public static void SwitchToolGroupPatch(ToolGroup? toolGroup, ToolGroupManager __instance)
+        public static void SwitchToolGroupPatch(ToolGroup? toolGroup, ToolGroupManager __instance, EventBus ____eventBus)
         {
             ToolButtonPatcher.ActiveToolButton?.Root.EnableInClassList("button--active", false);
 
@@ -35,6 +36,8 @@ namespace TimberApi.BottomBarSystem.Patchers
             {
                 return;
             }
+            
+            ____eventBus.Post(new ToolGroupExitedEvent(__instance.ActiveToolGroup));
             
             __instance.ActiveToolGroup = ExitingToolGroup;
         }

--- a/Core/TimberApi/ToolGroupSystem/ExitingToolGroup.cs
+++ b/Core/TimberApi/ToolGroupSystem/ExitingToolGroup.cs
@@ -1,13 +1,12 @@
 using Timberborn.ConstructionMode;
-using Timberborn.ForestryUI;
-using Timberborn.PlantingUI;
+using Timberborn.ToolSystem;
 
 namespace TimberApi.ToolGroupSystem
 {
     /// <summary>
-    ///     Add all mode enablers in this class to deactivate them on exiting a group
+    ///     Requires IConstructionModeEnabler to disable construction mode even when it's in the other ToolGroups, reason is unknown.
     /// </summary>
-    public class ExitingTool : TreeCuttingAreaToolGroup, IConstructionModeEnabler, IPlantingToolGroup
+    public class ExitingToolGroup : ToolGroup, IConstructionModeEnabler
     {
     }
 }

--- a/Core/TimberApi/ToolGroupSystem/ToolGroupConfigurator.cs
+++ b/Core/TimberApi/ToolGroupSystem/ToolGroupConfigurator.cs
@@ -2,6 +2,7 @@ using Bindito.Core;
 using TimberApi.ConfiguratorSystem;
 using TimberApi.SceneSystem;
 using TimberApi.SpecificationSystem;
+using TimberApi.ToolGroupSystem.ToolGroups.BuilderPriority;
 using TimberApi.ToolGroupSystem.ToolGroups.ConstructionMode;
 using TimberApi.ToolGroupSystem.ToolGroups.Default;
 using TimberApi.ToolGroupSystem.ToolGroups.PlantingMode;
@@ -22,6 +23,7 @@ namespace TimberApi.ToolGroupSystem
             containerDefinition.MultiBind<IToolGroupFactory>().To<DefaultToolGroupFactory>().AsSingleton();
             containerDefinition.MultiBind<IToolGroupFactory>().To<PlantingModeToolGroupFactory>().AsSingleton();
             containerDefinition.MultiBind<IToolGroupFactory>().To<TreeCuttingAreaToolGroupFactory>().AsSingleton();
+            containerDefinition.MultiBind<IToolGroupFactory>().To<BuilderPriorityToolGroupFactory>().AsSingleton();
             containerDefinition.MultiBind<ISpecificationGenerator>().To<TimberbornGroupGenerator>().AsSingleton();
         }
     }

--- a/Core/TimberApi/ToolGroupSystem/ToolGroups/BuilderPriority/BuilderPriorityToolGroup.cs
+++ b/Core/TimberApi/ToolGroupSystem/ToolGroups/BuilderPriority/BuilderPriorityToolGroup.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+namespace TimberApi.ToolGroupSystem.ToolGroups.BuilderPriority
+{
+    public sealed class BuilderPriorityToolGroup : Timberborn.BuilderPrioritySystemUI.BuilderPriorityToolGroup, IToolGroup
+    {
+        public BuilderPriorityToolGroup(string id, string? groupId, int order, string section, string displayNameLocKey, bool devMode, Sprite icon)
+        {
+            Id = id;
+            DisplayNameLocKey = displayNameLocKey;
+            Order = order;
+            Icon = icon;
+            DevMode = devMode;
+            Section = section;
+            GroupId = groupId;
+        }
+
+        public string Id { get; }
+
+        public string? GroupId { get; }
+
+        public int Order { get; }
+
+        public string Section { get; }
+
+        public bool DevMode { get; }
+    }
+}

--- a/Core/TimberApi/ToolGroupSystem/ToolGroups/BuilderPriority/BuilderPriorityToolGroupFactory.cs
+++ b/Core/TimberApi/ToolGroupSystem/ToolGroups/BuilderPriority/BuilderPriorityToolGroupFactory.cs
@@ -1,0 +1,20 @@
+namespace TimberApi.ToolGroupSystem.ToolGroups.BuilderPriority
+{
+    public class BuilderPriorityToolGroupFactory : IToolGroupFactory
+    {
+        public string Id => "BuilderPriorityToolGroup";
+
+        public IToolGroup Create(ToolGroupSpecification toolGroupSpecification)
+        {
+            return new BuilderPriorityToolGroup(
+                toolGroupSpecification.Id,
+                toolGroupSpecification.GroupId,
+                toolGroupSpecification.Order,
+                toolGroupSpecification.Section,
+                toolGroupSpecification.NameLocKey,
+                toolGroupSpecification.DevMode,
+                toolGroupSpecification.Icon
+            );
+        }
+    }
+}

--- a/Core/TimberApi/ToolSystem/ToolService.cs
+++ b/Core/TimberApi/ToolSystem/ToolService.cs
@@ -45,6 +45,7 @@ namespace TimberApi.ToolSystem
                 var toolFactory = _toolFactoryService.Get(specification.Type);
 
                 var tool = specification.GroupId is null ? toolFactory.Create(specification) : toolFactory.Create(specification, (ToolGroup) _toolGroupService.GetToolGroup(specification.GroupId));
+
                 tools.Add(specification.Id.ToLower(), tool);
 
                 var toolButton = _toolButtonFactoryService.Get(specification.Layout).Create(tool, specification);

--- a/Core/TimberApi/ToolSystem/Tools/BuilderPriority/BuilderPriorityToolGenerator.cs
+++ b/Core/TimberApi/ToolSystem/Tools/BuilderPriority/BuilderPriorityToolGenerator.cs
@@ -43,7 +43,7 @@ namespace TimberApi.ToolSystem.Tools.BuilderPriority
                 Id = "Priority",
                 Layout = "Blue",
                 Order = 50,
-                Type = "DefaultToolGroup",
+                Type = "BuilderPriorityToolGroup",
                 NameLocKey = "ToolGroups.Priority",
                 Icon = "Sprites/BottomBar/PriorityToolGroupIcon",
                 Section = "BottomBar",

--- a/Core/TimberApi/ToolSystem/Tools/SettingBox/SettingBoxTool.cs
+++ b/Core/TimberApi/ToolSystem/Tools/SettingBox/SettingBoxTool.cs
@@ -20,7 +20,7 @@ namespace TimberApi.ToolSystem.Tools.SettingBox
 
         public override void Enter()
         {
-            _toolGroupManager.SwitchToolGroup(new ExitingTool());
+            _toolGroupManager.SwitchToolGroup(new ExitingToolGroup());
             _eventBus.Post(new ShowOptionsEvent());
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 ### Changes
+- Updated `ExitToolGroup`, does not require most group types to disable them after closing
+- Changed `SwitchToolGroupPatch` so it will trigger the `ExitToolGroup` and the original group
+- Added `BuilderPriorityToolGroup`
 
 ## TimberAPI v0.6.0.0
 


### PR DESCRIPTION
The building priority highlighting stayed open after going out of the group with right mouse click.
The priority highlight got removed if you have a priority tool active and manually open another group.

Changed switching behaviour of tool so that in the ExitToolGroup event will be called twice now with the `ExitingToolGroup` and the toolgroup that is closed. It is not optimal usage but will give less restrictions on ToolGroup behaviour based on ExitingToolGroup.